### PR TITLE
Documenting the use of OAuth tokens in place of Legacy Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You'll want:
 
 OAuth Tokens
 ----------
-It's possible to use OAuth Tokens in Slack App [instead of a Legacy Token](https://github.com/nlopes/slack/issues/184).  Using the bot and users.profile OAuth Scopes, it's possible to generate an access token which functions similarly to the Legacy Token but with more tailored permissions. To achieve this you'll need to:
+It's possible to use OAuth Tokens in Slack App [instead of a Legacy Token](https://github.com/nlopes/slack/issues/184).  Using the bot and users.profile OAuth Scopes, the access token functions similarly to the Legacy Token but with more tailored permissions. To achieve this you'll need to:
 
 1. Create a [Slack App](https://api.slack.com/apps)  
 2. Add the bot and users.profile:read [OAuth Scopes](https://api.slack.com/docs/presence-and-status)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ You'll want:
 
 OAuth Tokens
 ----------
-It's possible to use OAuth Tokens in Slack App [instead of a Legacy Token](https://github.com/nlopes/slack/issues/184).  Using the bot and users.profile OAuth Scopes, the access token functions similarly to the Legacy Token but with more tailored permissions. To achieve this you'll need to:
+It's possible to use OAuth Tokens in Slack App [instead of a Legacy Token](https://github.com/nlopes/slack/issues/184).  Using the bot and users.profile OAuth Scopes, the access token functions similarly to the Legacy Token but with more tailored permissions. 
+To achieve this you'll need to:
 
 1. Create a [Slack App](https://api.slack.com/apps)  
 2. Add the bot and users.profile:read [OAuth Scopes](https://api.slack.com/docs/presence-and-status)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ You'll want:
 - a slack api
 - ...
 
+
+OAuth Permissions
+----------
+It's possible to use a Bot User in Slack App instead of a Legacy Token.  Using the bot and users.profile OAuth Scopes, it's possible to generate an access token which functions similarly to the Legacy Token but with more tailored permissions. To achieve this you'll need to:
+
+1. Create a [Slack App](https://api.slack.com/apps)  
+2. Add the bot and users.profile:read [OAuth Scopes](https://api.slack.com/docs/presence-and-status)
+3. Use the Bot User OAuth Access Token in place of the Legacy Token
+
+If your Slack App does not contain a bot OAuth scope, you will not see an option for the Bot User Access Token, and attempting to connect with the default OAuth Token may result in a missing_scope error from the Slack API.
+
+
 References
 ----------
 

--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ You'll want:
 - ...
 
 
-OAuth Permissions
+OAuth Tokens
 ----------
-It's possible to use a Bot User in Slack App instead of a Legacy Token.  Using the bot and users.profile OAuth Scopes, it's possible to generate an access token which functions similarly to the Legacy Token but with more tailored permissions. To achieve this you'll need to:
+It's possible to use OAuth Tokens in Slack App [instead of a Legacy Token](https://github.com/nlopes/slack/issues/184).  Using the bot and users.profile OAuth Scopes, it's possible to generate an access token which functions similarly to the Legacy Token but with more tailored permissions. To achieve this you'll need to:
 
 1. Create a [Slack App](https://api.slack.com/apps)  
 2. Add the bot and users.profile:read [OAuth Scopes](https://api.slack.com/docs/presence-and-status)

--- a/server/go/main.go
+++ b/server/go/main.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	slackUserID      = "YOURUSERID"
-	slackLegacyToken = "YOURLEGACYTOKEN"
+	slackUserID = "YOURUSERID"
+	slackToken  = "YOURLEGACYTOKEN"
 )
 
 func initializePort(path string) *serial.Port {
@@ -110,7 +110,7 @@ func main() {
 
 	// establish our slack connection, generate a legacy user token for this connection
 	api := slack.New(
-		slackLegacyToken,
+		slackToken,
 		slack.OptionDebug(false),
 		slack.OptionLog(log.New(os.Stdout, "slack-bot: ", log.Lshortfile|log.LstdFlags)),
 	)


### PR DESCRIPTION
Took a minute to figure out how the slack app needed to be set up, hopefully this extra documentation might help the next person trying to implement this without legacy tokens